### PR TITLE
Fixed summary rendering issue

### DIFF
--- a/content/blog/bodgetheme/20200316_markdown/index.md
+++ b/content/blog/bodgetheme/20200316_markdown/index.md
@@ -3,11 +3,10 @@ date        : 2020-03-16T18:42:02+01:00
 draft       : false
 title       : "Blogpage formatting - markdown"
 author      : "Elborro"
-description : "Markdown formatting tests."
 
 # Description overrides the automated summary of marked-up content
 #  at the bottom of this file.
-description : ""
+description : "Markdown formatting tests."
 
 # Identifying mnemonics, INTERNAL use only. Fill AT LEAST one identifying
 # mnemonic, to refer to the project this blog is related to.

--- a/content/blog/bodgetheme/20200404_built_in_shortcodes/index.md
+++ b/content/blog/bodgetheme/20200404_built_in_shortcodes/index.md
@@ -3,11 +3,10 @@ date        : 2020-04-04T09:24:02+01:00
 draft       : false
 title       : "Blogpage formatting - built in shortcodes"
 author      : "Elborro"
-description : "Testing Hugo built in shortcodes (and check for requirement to replace any)."
 
 # Description overrides the automated summary of marked-up content
 #  at the bottom of this file.
-description : ""
+description : "Testing Hugo built in shortcodes (and check for requirement to replace any)."
 
 # Identifying mnemonics, INTERNAL use only. Fill AT LEAST one identifying
 # mnemonic, to refer to the project this blog is related to.

--- a/content/blog/bodgetheme/20200404_theme_shortcodes/index.md
+++ b/content/blog/bodgetheme/20200404_theme_shortcodes/index.md
@@ -3,7 +3,6 @@ date        : 2020-04-04T10:31:02+01:00
 draft       : false
 title       : "Bodgetheme shortcodes"
 author      : "Elborro"
-description : "Testing additional Bodgetheme shortcodes."
 
 # Description overrides the automated summary of marked-up content
 #  at the bottom of this file.
@@ -52,6 +51,10 @@ gallery:
     caption : "People"
     exclude : false
 ---
+
+Testing additional Bodgetheme shortcodes.
+
+<!--more-->
 
 ## Additional Bodgetheme shortcodes
 

--- a/content/blog/bodgetheme/20200406_images/index.md
+++ b/content/blog/bodgetheme/20200406_images/index.md
@@ -3,7 +3,6 @@ date        : 2020-04-06T14:21:02+01:00
 draft       : false
 title       : "Blogpage images"
 author      : "Elborro"
-description : "While standard formatting should deliver quite a clean page, someone might want to add images at a later stage."
 
 # Description overrides the automated summary of marked-up content
 #  at the bottom of this file.
@@ -31,8 +30,8 @@ icon_name : fa-pencil
 icon_pack : fa
 
 # Default image related to this blog
-image_src   : "images/bodgeteam.jpg"
-image_alt   : "Bodgenators"
+image_src   : ""
+image_alt   : ""
 thumb_src   : ""
 thumb_alt   : ""
 
@@ -52,6 +51,10 @@ gallery:
     caption : "People"
     exclude : false
 ---
+
+While standard formatting should deliver quite a clean page, someone might want to add images at a later stage. This shows how to share nice pictures in your blog-posts.
+
+<!--more-->
 
 ## Inserting images in text
 

--- a/content/blog/bodgetheme/20200408_taxonomy/index.md
+++ b/content/blog/bodgetheme/20200408_taxonomy/index.md
@@ -3,7 +3,6 @@ date        : 2020-04-08T23:29:02+01:00
 draft       : false
 title       : "Taxonomy tests"
 author      : "Elborro"
-description : "Test for taxonomies and related shortcodes to display them in blog posts. Just a simplified overview for now. Polishing can be done later."
 
 # Description overrides the automated summary of marked-up content
 #  at the bottom of this file.
@@ -53,17 +52,21 @@ gallery:
     exclude : false
 ---
 
-## List teams
+Taxonomies allow to inventory all teammembers, projects in progress, etc. Test for taxonomies and related shortcodes to display them in blog posts. Just a simplified overview for now. Polishing can be done later.
+
+<!--more-->
+
+#### List teams
 {{< list-teams >}}
 
-## List projects
+#### List projects
 {{< list-projects >}}
 
-## List categories
+#### List categories
 {{< list-categories >}}
 
-## List tags
+#### List tags
 {{< list-tags >}}
 
-## Tag cloud
+#### Tag cloud
 {{< taxo-cloud >}}

--- a/content/blog/bodgetheme/20200410_gallery/index.md
+++ b/content/blog/bodgetheme/20200410_gallery/index.md
@@ -3,7 +3,6 @@ date        : 2020-04-10T12:59:04+01:00
 draft       : false
 title       : "Gallery test"
 author      : "Elborro"
-description : "Testing gallery shortcode implementation"
 
 # Description overrides the automated summary of marked-up content
 #  at the bottom of this file.
@@ -55,5 +54,9 @@ gallery:
   caption : "Cambodge"
   exclude : false
 ---
+
+##### Testing gallery shortcode implementation
+
+<!--more-->
 
 {{< gallery >}}

--- a/content/blog/bodgetheme/20200419_shortcodes/index.md
+++ b/content/blog/bodgetheme/20200419_shortcodes/index.md
@@ -4,7 +4,6 @@ lastmod     : 2020-04-25T22:31:57+02:00
 draft       : false
 title       : "Testing with shortcodes"
 author      : "Elborro"
-description : ""
 
 # Description overrides the automated summary of marked-up content
 #  at the bottom of this file.

--- a/content/blog/bodgetheme/20200426_herewego/index.md
+++ b/content/blog/bodgetheme/20200426_herewego/index.md
@@ -32,7 +32,7 @@ icon_name : fa-pencil
 icon_pack : fa
 
 # Default image related to this blog
-image_src   : "images/mascot.png"
+image_src   : ""
 image_alt   : ""
 thumb_src   : ""
 thumb_alt   : ""
@@ -54,7 +54,8 @@ gallery:
     exclude : false
 ---
 
-### {{< icon name="fa-suitcase" >}} 20200426_herewego Project
+Welcome to this blog page of the 20200426_herewego project. This page is work in progress and should be filled with new content soon.
 
-Welcome to the project page of the 20200426_herewego project. This project page is still a work in progress and we expect to fill it with content soon.
-{{< img src="/images/wip.png" alt="Work in progress." width="50%"  >}}
+<!--more-->
+
+This part of the text will show up on the blog page only, not in the previews of the project page.

--- a/content/blog/pixel2020/20200419_newapp/index.md
+++ b/content/blog/pixel2020/20200419_newapp/index.md
@@ -1,7 +1,7 @@
 ---
 date        : 2020-04-19T13:38:33+02:00
 lastmod     : 2020-04-19T13:38:33+02:00
-draft       : true
+draft       : false
 title       : "Cool new app!"
 author      : "tom"
 

--- a/content/project/pixel2020/index.md
+++ b/content/project/pixel2020/index.md
@@ -1,7 +1,7 @@
 ---
 date        : 2020-01-24T09:21:42+01:00
 lastmod     : 2020-01-24T09:21:42+01:00
-draft       : true
+draft       : false
 short_title : "Pixel Badge"
 title       : "Pixel Badge Project"
 description : "Let's take the CampZone 2019 badge to the next level."

--- a/themes/bodgetheme/archetypes/blog/index.md
+++ b/themes/bodgetheme/archetypes/blog/index.md
@@ -27,6 +27,7 @@ categories  :
 - Embedded software
 
 # Blog icon
+# For available icons, see: https://fontawesome.com
 icon_name : fa-pencil
 icon_pack : fa
 
@@ -51,6 +52,16 @@ gallery:
   - image   : "people.jpg"
     caption : "People"
     exclude : false
+
+# Write the content of this blog page below in markup language.
+# An emoji cheat sheet can be found here:
+#  https://www.webfx.com/tools/emoji-cheat-sheet/
 ---
 
-Welcome to the project page of the {{ replace .Name "-" " " | title }} project. This project page is still a work in progress and we expect to fill it with content soon.
+##### {{ replace .Name "-" " " | title }} project blog page.
+
+Welcome to this blog page of the {{ replace .Name "-" " " | title }} project. This page is work in progress and should be filled with new content soon.
+
+<!--more-->
+
+This part of the text will show up on the blog page only, not in the previews of the project page.

--- a/themes/bodgetheme/archetypes/project/index.md
+++ b/themes/bodgetheme/archetypes/project/index.md
@@ -29,6 +29,7 @@ categories  :
 - Embedded software
 
 # Project icon
+# For available icons, see: https://fontawesome.com
 icon_name : fa-suitcase
 icon_pack : fa
 

--- a/themes/bodgetheme/archetypes/team/index.md
+++ b/themes/bodgetheme/archetypes/team/index.md
@@ -29,6 +29,7 @@ bio : ""
 fullname : {{ replace .Name "-" " " | title }}
 
 # Name icon (Shown in front of your name on profile)
+# For available icons, see: https://fontawesome.com
 icon_name : fa-address-card
 icon_pack : fa
 

--- a/themes/bodgetheme/layouts/blog/list.html
+++ b/themes/bodgetheme/layouts/blog/list.html
@@ -23,12 +23,14 @@
         <span class="bt-blog-list-date w3-left w3-opacity w3-small">{{ .Lastmod.Format "Monday, 02 January 2006 15:04 MST" }}</span>
       </div>
       <div class="bt-blog-list-description w3-container">
-        <p>{{ if .Description }}{{ .Description }}{{ else }}{{ .Summary }}{{ end }}</p>
+        <p>{{ if .Description }}{{ .Description }}{{ else }}{{ .Summary | plainify | emojify }}{{ end }}</p>
+        {{- if or (.Description) (.Truncated) }}
         <div class="bt-blog-list-description-read-more-row w3-row">
           <div class="bt-blog-list-description-read-more-col w3-col m8 s12">
             <p class="bt-blog-list-description-read-more-title"><a class="bt-blog-list-description-read-more-link w3-button w3-padding-large w3-white w3-border" title="Read More" alt="Read More" href="{{ .Permalink }}"><b>READ MORE &raquo;</b></a></p>
           </div>
         </div>
+        {{- end }}
       </div>
     </div>
     {{- end }}

--- a/themes/bodgetheme/layouts/project/single.html
+++ b/themes/bodgetheme/layouts/project/single.html
@@ -47,12 +47,14 @@
         <span class="bt-project-single-date w3-left w3-opacity w3-small">{{ .Date.Format "Monday, 02 January 2006 15:04 MST" }}{{if .Params.Author}} - {{ if $link }}<a href="{{ $link }}">{{ end }}{{ $author }}{{ if $link }}</a>{{ end }}{{ end }}</span>
       </div>
       <div class="bt-project-single-description w3-container">
-        <p>{{ if .Description }}{{ .Description }}{{ else }}{{ .Summary }}{{ end }}</p>
+        <p>{{ if .Description }}{{ .Description }}{{ else }}{{ .Summary | plainify | emojify }}{{ end }}</p>
+        {{- if or (.Description) (.Truncated) }}
         <div class="bt-project-single-read-more-row w3-row">
           <div class="bt-project-single-read-more-col w3-col m12 s12">
             <p class="bt-project-single-read-more-title w3-right"><a class="w3-button w3-padding-large w3-white w3-border" title="Read More" alt="Read More" href="{{ .Permalink }}"><b>READ MORE &Rang;</b></a></p>
           </div>
         </div>
+        {{- end }}
       </div>
     </div>
     {{ end }}


### PR DESCRIPTION
Solved a summary render issue. Shortcodes are not rendered before the summary will be created. For now solved with description and/or manual cutting. Quite easy to do, but I really would prefer to solve the summary render itself some day.