### PR TITLE
Feature/bodgetheme

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -27,7 +27,7 @@ updateSections = ["blog","project"]
 
 [theme]
   generator = "Badge.team Bodgetheme"
-  revision  = 2020-05-22T13:37:42Z
+  revision  = 2020-05-23T13:37:42Z
   author    = "Noor Draconia, Rob Verseijden"
 
 [robots]

--- a/content/blog/bodgetheme2020/20200505_hh2020_sweatshop/index.md
+++ b/content/blog/bodgetheme2020/20200505_hh2020_sweatshop/index.md
@@ -45,155 +45,155 @@ gallery:
   - image        : "photo01.jpg"
     caption      : "Sweating Bodgers"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_140149_-_DSC08744.jpg"
   - image        : "photo02.jpg"
     caption      : "Removing FETs"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_140909_-_DSC08749.jpg"
   - image        : "photo03.jpg"
     caption      : "Bodging Fanatics"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_141119_-_DSC08757.jpg"
   - image        : "photo04.jpg"
     caption      : "The Harvest"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_141010_-_DSC08753.jpg"
   - image        : "photo05.jpg"
     caption      : "Trimming long leads"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_141414_-_DSC08769.jpg"
   - image        : "photo06.jpg"
     caption      : "Loads of battery boxes"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_141356_-_DSC08767.jpg"
   - image        : "photo07.jpg"
     caption      : "Removing with hot air"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_150645_-_DSC08816.jpg"
   - image        : "photo08.jpg"
     caption      : "Replacing the diode"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_141658_-_DSC08772.jpg"
   - image        : "photo09.jpg"
     caption      : "Badge on jig"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_141842_-_DSC08775.jpg"
   - image        : "photo10.jpg"
     caption      : "Programming jig"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_141848_-_DSC08776.jpg"
   - image        : "photo11.jpg"
     caption      : "STICKERS!"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_142121_-_DSC08786.jpg"
   - image        : "photo12.jpg"
     caption      : "Exhausted Bodhajes"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_195156_-_DSC08904.jpg"
   - image        : "photo13.jpg"
     caption      : "Noseyhaj"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_202322_-_DSC08910.jpg"
   - image        : "photo14.jpg"
     caption      : "Adventure then Pizza"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_190334_-_DSC08898.jpg"
   - image        : "photo15.jpg"
     caption      : "Chase the flavors"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_190348_-_DSC08899.jpg"
   - image        : "photo16.jpg"
     caption      : "Pizza with love"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_190908_-_DSC08900.jpg"
   - image        : "photo17.jpg"
     caption      : "Oh yes we did!"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_195928_-_DSC08905.jpg"
   - image        : "photo18.jpg"
     caption      : "Measure. Meditate. Cut!"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_154541_-_DSC08835.jpg"
   - image        : "photo19.jpg"
     caption      : "Monks work"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_165602_-_DSC08863.jpg"
   - image        : "photo20.jpg"
     caption      : "Bodge-planning"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_155709_-_DSC08844.jpg"
   - image        : "photo21.jpg"
     caption      : "Tinning"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_155146_-_DSC08839.jpg"
   - image        : "photo22.jpg"
     caption      : "Precision work"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_182210_-_DSC08889.jpg"
   - image        : "photo23.jpg"
     caption      : "Push and pray ..."
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_221535_-_DSC08934.jpg"
   - image        : "photo24.jpg"
     caption      : "... HURRAY!"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_221639_-_DSC08936.jpg"
   - image        : "photo25.jpg"
     caption      : "QC failures"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_203047_-_DSC08915.jpg"
   - image        : "photo26.jpg"
     caption      : "QC failures"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_202735_-_DSC08914.jpg"
   - image        : "photo27.jpg"
     caption      : "Fixed the easy-fixers first"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_211455_-_DSC08925.jpg"
   - image        : "photo28.jpg"
     caption      : "Scrutinizing bugged badges"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_213907_-_DSC08928.jpg"
   - image        : "photo29.jpg"
     caption      : "May be we fixed this bugger"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_213950_-_DSC08929.jpg"
   - image        : "photo30.jpg"
     caption      : "Beathaj"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_222744_-_DSC08941.jpg"
   - image        : "photo31.jpg"
     caption      : "Bodgefield remains"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_222806_-_DSC08942.jpg"
   - image        : "photo32.jpg"
     caption      : "Hobbybob sealed the boxes"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_223743_-_DSC08950.jpg"
   - image        : "photo33.jpg"
     caption      : "Debodination swept"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_231810_-_DSC08955.jpg"
   - image        : "photo34.jpg"
     caption      : "Toys!"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_223216_-_DSC08947.jpg"
   - image        : "photo35.jpg"
     caption      : "Badges ..."
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_140754_-_DSC08745.jpg"
   - image        : "photo36.jpg"
     caption      : "... more badges ..."
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_142111_-_DSC08785.jpg"
   - image        : "photo37.jpg"
     caption      : "... even more badges"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_142059_-_DSC08784.jpg"
   - image        : "photo38.jpg"
     caption      : "HÅJ!"
     exclude      : false
-    external_url : ""
+    external_url : "https://gallery.bodge.team/hackerhotel2020/2020-02-01-sweatshop-1/imgs/2020-02-01_204108_-_DSC08920.jpg"
 
 # Write the content of this blog page below in markup language.
 # An emoji cheat sheet can be found here:

--- a/content/blog/bodgetheme2020/20200505_hh2020_sweatshop/index.md
+++ b/content/blog/bodgetheme2020/20200505_hh2020_sweatshop/index.md
@@ -1,6 +1,6 @@
 ---
 date        : 2020-05-05T00:00:00+02:00
-lastmod     : 2020-05-21T22:23:00+02:00
+lastmod     : 2020-05-23T18:53:00+02:00
 draft       : false
 title       : "Blog page rewrite test"
 author      : "elborro"

--- a/content/blog/bodgetheme2020/20200521_img_shortcode/index.md
+++ b/content/blog/bodgetheme2020/20200521_img_shortcode/index.md
@@ -1,6 +1,6 @@
 ---
 date        : 2020-05-21T19:08:17+02:00
-lastmod     : 2020-05-22T18:58:42+02:00
+lastmod     : 2020-05-23T15:01:42+02:00
 draft       : false
 title       : "New img shortcode for blogpage images"
 author      : "Elborro"
@@ -166,7 +166,7 @@ Since other parameters were not specified, the images are *filled* to a *250x250
 When not specified, the shortcode will use *Fill* for all images.
 
 ##### **Resize**
-Resize with width of 500px and preserve ratio, specify size as "500x" or "x500" for height 500px and preserve ratio. "500x500" will squeeze the image to fit without preserving ratio.
+Resize with width of 500px and preserve ratio. Specify size as "500x" for width 500px and preserve ratio or "x500" for height 500px and preserve ratio. "500x500" will squeeze the image to fit.
 
 {{< highlight html >}}
 {{</* img src="images/bodgeteam.jpg,images/mascot.png" method="resize" */>}}
@@ -175,7 +175,7 @@ Resize with width of 500px and preserve ratio, specify size as "500x" or "x500" 
 {{< img src="images/bodgeteam.jpg,images/mascot.png" method="resize" colour="#ffffff" >}}
 
 ##### **Fit**
-Scales down the image while preserving the ratio, until it fits either specified height or width. When specified with the 'size' parameter, both height and width are required parameters.
+Scales down the image while preserving the ratio, until it fits either specified height or width. Specifying size as "500x" or "x500" will estimate the other dimension preserving the current ratio.
 
 {{< highlight html >}}
 {{</* img src="images/bodgeteam.jpg,images/mascot.png" method="fit" */>}}
@@ -184,7 +184,7 @@ Scales down the image while preserving the ratio, until it fits either specified
 {{< img src="images/bodgeteam.jpg,images/mascot.png" method="fit" colour="#ffffff" >}}
 
 ##### **Fill**
-Resizes and crops the image to match both given dimensions. When specified with the 'size' parameter, both height and width are required parameters.
+Resizes and crops the image to match both given dimensions. Specifying size as "500x" or "x500" will estimate the other dimension preserving the current ratio.
 
 {{< highlight html >}}
 {{</* img src="images/bodgeteam.jpg,images/mascot.png" method="fill" */>}}
@@ -193,7 +193,7 @@ Resizes and crops the image to match both given dimensions. When specified with 
 {{< img src="images/bodgeteam.jpg,images/mascot.png" method="fill" colour="#ffffff" >}}
 
 ##### **None**
-Skips image processing and show original image. This disables the generation of coloured tiles for missing pictures as well.
+Skips image processing and show original image. This disables background colour and the generation of coloured tiles for missing pictures.
 
 {{< highlight html >}}
 {{</* img src="images/bodgeteam.jpg,images/mascot.png" method="none" */>}}

--- a/content/blog/bodgetheme2020/20200521_img_shortcode/index.md
+++ b/content/blog/bodgetheme2020/20200521_img_shortcode/index.md
@@ -463,3 +463,34 @@ capcol="white"
 {{</ highlight>}}
 
 {{< img src="unknown01.jpg,unknown02.jpg,unknown03.jpg,unknown04.jpg,unknown05.jpg,unknown06.jpg" caption="*Image 01*,~~Image 02~~,**Image 03**,*Image 04*,~~Image 05~~,**Image 06**" cappos="middle" capcol="white" >}}
+
+
+---
+
+#### Testing
+
+{{< highlight html >}}
+{{</* img album="images" src="bodgeteam.jpg,mascot.png" size="300x" */>}}
+{{</ highlight>}}
+
+{{< img album="images" src="bodgeteam.jpg,mascot.png" method="fit" size="x150" >}}
+
+{{< highlight html >}}
+{{</* img album="images" src="bodgeteam.jpg,mascot.png" size="300x" */>}}
+{{</ highlight>}}
+
+{{< img album="images" src="bodgeteam.jpg,mascot.png" size="x150" >}}
+
+
+
+{{< highlight html >}}
+{{</* img album="images" src="voyage-cambodge.jpg" size="300x" */>}}
+{{</ highlight>}}
+
+{{< img album="images" src="voyage-cambodge.jpg" size="300x" >}}
+
+{{< highlight html >}}
+{{</* img album="images" src="voyage-cambodge.jpg" size="x150" */>}}
+{{</ highlight>}}
+
+{{< img album="images" src="voyage-cambodge.jpg" size="x150" option="nourl" >}}

--- a/content/blog/bodgetheme2020/20200521_img_shortcode/index.md
+++ b/content/blog/bodgetheme2020/20200521_img_shortcode/index.md
@@ -463,34 +463,3 @@ capcol="white"
 {{</ highlight>}}
 
 {{< img src="unknown01.jpg,unknown02.jpg,unknown03.jpg,unknown04.jpg,unknown05.jpg,unknown06.jpg" caption="*Image 01*,~~Image 02~~,**Image 03**,*Image 04*,~~Image 05~~,**Image 06**" cappos="middle" capcol="white" >}}
-
-
----
-
-#### Testing
-
-{{< highlight html >}}
-{{</* img album="images" src="bodgeteam.jpg,mascot.png" size="300x" */>}}
-{{</ highlight>}}
-
-{{< img album="images" src="bodgeteam.jpg,mascot.png" method="fit" size="x150" >}}
-
-{{< highlight html >}}
-{{</* img album="images" src="bodgeteam.jpg,mascot.png" size="300x" */>}}
-{{</ highlight>}}
-
-{{< img album="images" src="bodgeteam.jpg,mascot.png" size="x150" >}}
-
-
-
-{{< highlight html >}}
-{{</* img album="images" src="voyage-cambodge.jpg" size="300x" */>}}
-{{</ highlight>}}
-
-{{< img album="images" src="voyage-cambodge.jpg" size="300x" >}}
-
-{{< highlight html >}}
-{{</* img album="images" src="voyage-cambodge.jpg" size="x150" */>}}
-{{</ highlight>}}
-
-{{< img album="images" src="voyage-cambodge.jpg" size="x150" option="nourl" >}}

--- a/themes/bodgetheme/layouts/shortcodes/img.html
+++ b/themes/bodgetheme/layouts/shortcodes/img.html
@@ -203,9 +203,16 @@
       {{- else if in . "notit" }}{{ $title_text = "" }}
       {{- end }}
     {{- end }}
+
+    {{- $target := "" }}
+    {{- if $url }}
+      {{- if not (in $url $.Site.BaseURL) }}
+        {{- $target = "_blank"}}
+      {{- end }}
+    {{- end }}
   <div class="bi-img bt-display-container bt-margin-bottom {{ $alignment }}" style="width:{{ $image.Width }}">
     {{- if $url }}
-    <a title="{{ $cap_text }}" href="{{ $url }}" style="text-decoration:none;">
+    <a title="{{ $cap_text }}" href="{{ $url }}"{{ if $target }} target="{{ $target }}"{{ end }} style="text-decoration:none;">
     {{- end }}
       <div class="bi-img-caption bt-display-container">
         <img class="bi-img-img bi-image" src="{{ if $image }}{{ $image.RelPermalink }}{{ else }}{{ . }}{{ end }}"{{ if $alt_text}} alt="{{ $alt_text }}"{{ end }}{{ if $title_text}} title="{{ $title_text }}"{{ end }} width="{{ $image.Width }}" height="{{ $image.Height }}">

--- a/themes/bodgetheme/layouts/shortcodes/img.html
+++ b/themes/bodgetheme/layouts/shortcodes/img.html
@@ -66,6 +66,20 @@
             {{- $bgcolour = index .tileColours $colourIndex }}
           {{- end }}
         {{- end }}
+
+        {{- $widthOnly := findRE "^(?P<width>[0-9]+)x$" $tileSize }}
+        {{- if $widthOnly }}
+          {{- $requestedWidth := float (strings.TrimRight "x" (index $widthOnly 0)) }}
+          {{- $newHeight := div (mul $requestedWidth $original.Height) $original.Width }}
+          {{- $tileSize = printf "%.0fx%.0f" $requestedWidth $newHeight }}
+        {{- end }}
+        {{- $heightOnly := findRE "^x(?P<height>[0-9]+)$" $tileSize }}
+        {{- if $heightOnly }}
+          {{- $requestedHeight := float (strings.TrimLeft "x" (index $heightOnly 0)) }}
+          {{- $newWidth := div (mul $requestedHeight $original.Width) $original.Height }}
+          {{- $tileSize = printf "%.0fx%.0f" $newWidth $requestedHeight }}
+        {{- end }}
+
         {{-      if eq $method "fit"    }}{{ $image = $original.Fit    (printf "%s %s %s" $tileSize $ipcmds $bgcolour) }}
         {{- else if eq $method "resize" }}{{ $image = $original.Resize (printf "%s %s %s" $tileSize $ipcmds $bgcolour) }}
         {{- else if eq $method "none"   }}{{ $image = $original }}
@@ -74,6 +88,20 @@
     {{- else }}
       {{- if $original }}
         {{- $tileSize := $size | default "250x250" }}
+
+        {{- $widthOnly := findRE "^(?P<width>[0-9]+)x$" $tileSize }}
+        {{- if $widthOnly }}
+          {{- $requestedWidth := float (strings.TrimRight "x" (index $widthOnly 0)) }}
+          {{- $newHeight := div (mul $requestedWidth $original.Height) $original.Width }}
+          {{- $tileSize = printf "%.0fx%.0f" $requestedWidth $newHeight }}
+        {{- end }}
+        {{- $heightOnly := findRE "^x(?P<height>[0-9]+)$" $tileSize }}
+        {{- if $heightOnly }}
+          {{- $requestedHeight := float (strings.TrimLeft "x" (index $heightOnly 0)) }}
+          {{- $newWidth := div (mul $requestedHeight $original.Width) $original.Height }}
+          {{- $tileSize = printf "%.0fx%.0f" $newWidth $requestedHeight }}
+        {{- end }}
+
         {{- $bgcolour := $colour | default "#ffffff" }}
         {{-      if eq $method "fill"   }}{{ $image = $original.Fill   (printf "%s %s %s" $tileSize $ipcmds $bgcolour) }}
         {{- else if eq $method "fit"    }}{{ $image = $original.Fit    (printf "%s %s %s" $tileSize $ipcmds $bgcolour) }}

--- a/themes/bodgetheme/layouts/shortcodes/img.html
+++ b/themes/bodgetheme/layouts/shortcodes/img.html
@@ -44,6 +44,10 @@
     {{- end }}
 
     {{- $original := $context.Page.Resources.GetMatch $filename }}
+    {{- $original_url := "" }}
+    {{- if $original }}
+      {{- $original_url = $original.RelPermalink }}
+    {{- end }}
 
     {{- with $.Site.Params.gridifier }}
       {{- if and (not $original) .defaultImage }}
@@ -128,6 +132,9 @@
     {{- end }}
 
     {{- $url := $img_url }}
+    {{- if and $original_url (not $url) }}
+      {{- $url = $original_url }}
+    {{- end }}
 
     {{- /* Get caption */}}
     {{- $cap_text := $img_cap }}

--- a/themes/bodgetheme/layouts/team/single.html
+++ b/themes/bodgetheme/layouts/team/single.html
@@ -95,7 +95,7 @@
     {{- with .Params.bio }}
     <div class="bi-team-single-bio bt-container bt-card bt-margin bt-white">
       <p class="bi-team-single-bio-title bt-large"><strong><i class="fa fa-address-card bi-icon bt-margin-right bt-text-teal"></i>{{ (i18n "biography" | default "Biography") | markdownify }}</strong></p>
-      <p class="bi-team-single-bio-content">{{ . }}</p>
+      <p class="bi-team-single-bio-content">{{ . | markdownify | emojify }}</p>
     </div>
     {{- end }}
 
@@ -156,12 +156,12 @@
         <h6 class="bi-team-single-projects-project-date bt-text-teal"><i class="fa fa-calendar bi-icon bt-margin-right"></i>{{ $startDate }}{{ if ne $startDate $endDate }} - {{ $endDate }}{{ end }}</h6>
         {{- if $page.Params.participation }}
           {{- range (where $page.Params.participation "project" "in" .Params.projects) }}
-            <p>{{ .role }} : {{ .description }}</p>
+            <p>{{ .role }} : {{ .description |  markdownify | emojify }}</p>
           {{- else }}
-          <p>{{ .Description }}</p>
+          <p>{{ .Description | markdownify | emojify }}</p>
           {{- end }}
         {{- else }}
-        <p>{{ .Description }}</p>
+        <p>{{ .Description |  markdownify | emojify }}</p>
         {{- end }}
       {{- end }}
     </div>


### PR DESCRIPTION
Added all external references to the hackerhotel 2020 example.
img-shortcode allows all forms of sizing "300x300", "300x" or "x300" for other image processors as well.
Update in blog post describing img-shortcode, to reflect this change.
Team member page: all descriptions are processed by markdown processor.